### PR TITLE
Add PHP Signature Verification Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Each example is in a separate directory, first level directories are the languag
 - [`go`](go/)
 - [`java`](java/)
 - [`javascript`](javascript/)
+- [`php`](php/)
 - [`python/cyrptodome`](python/cryptodome/)
 - [`python/ecdsa`](python/ecdsa)
 - [`ruby`](ruby/)

--- a/php/.gitignore
+++ b/php/.gitignore
@@ -1,0 +1,2 @@
+vendor/*
+composer.lock

--- a/php/README.md
+++ b/php/README.md
@@ -1,23 +1,14 @@
-# Signature Verification in javascript
+# Signature Verification in php
 
-This is a simple example of how to verify a signature in php. It uses mdanter's ecc library to do so.
+This is a simple example of how to verify a signature in php. It uses the `openssl_verify` function to verify the signature.
 
 ## Usage
 
 To run the example you can run:
 
-```
+```bash
 composer update
 php verify.php
 ```
 
-Note that the example as written will fail. You will need to replace:
-
-```php
-$signature = 'base64-encoded-signature';
-$publicKey = 'public-key-identifier';
-$githubToken = 'your-github-token';
-$payload = 'payload-data';
-```
-
-with actual values obtained from a Copilot request in order for the example to work. 
+[`verify.php`](verify.php) contains an example of how to verify the signature.

--- a/php/README.md
+++ b/php/README.md
@@ -1,0 +1,23 @@
+# Signature Verification in javascript
+
+This is a simple example of how to verify a signature in php. It uses mdanter's ecc library to do so.
+
+## Usage
+
+To run the example you can run:
+
+```
+composer update
+php verify.php
+```
+
+Note that the example as written will fail. You will need to replace:
+
+```php
+$signature = 'base64-encoded-signature';
+$publicKey = 'public-key-identifier';
+$githubToken = 'your-github-token';
+$payload = 'payload-data';
+```
+
+with actual values obtained from a Copilot request in order for the example to work. 

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,0 +1,6 @@
+{
+    "require": {
+        "guzzlehttp/guzzle": "^7.0",
+        "mdanter/ecc": "^0.5.0"
+    }
+}

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,5 @@
 {
     "require": {
-        "guzzlehttp/guzzle": "^7.0",
-        "mdanter/ecc": "^0.5.0"
+        "guzzlehttp/guzzle": "^7.0"
     }
 }

--- a/php/verify.php
+++ b/php/verify.php
@@ -1,0 +1,74 @@
+<?php
+
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use Mdanter\Ecc\Crypto\Signature\SignHasher;
+use Mdanter\Ecc\EccFactory;
+use Mdanter\Ecc\Crypto\Signature\Signer;
+use Mdanter\Ecc\Serializer\PublicKey\PemPublicKeySerializer;
+use Mdanter\Ecc\Serializer\PublicKey\DerPublicKeySerializer;
+use Mdanter\Ecc\Serializer\Signature\DerSignatureSerializer;
+
+class GithubSignatureVerifier
+{
+    public static function verify(string $signature, string $publicKey, string $token, string $payload): bool
+    {
+        // Fetch public keys from GitHub
+        $client = new Client();
+        $response = $client->get('https://api.github.com/copilot-keys', [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+            ]
+        ]);
+
+        $keyResponse = json_decode($response->getBody()->getContents());
+
+        foreach ($keyResponse->public_keys as $key) {
+            if ($key->key_identifier === $publicKey) {
+                $publicKey = $key->key;
+                break;
+            }
+        }
+
+        if (!$publicKey) {
+            echo 'Public key not found for copilot request';
+            return false;
+        }
+
+        // Decode the base64 signature
+        $sigData = base64_decode($signature);
+
+        $sigSerializer = new DerSignatureSerializer();
+        $sig = $sigSerializer->parse($sigData);
+
+        $adapter = EccFactory::getAdapter();
+        $generator = EccFactory::getNistCurves()->generator384();
+        $algorithm = 'sha256';
+
+        // Parse public key 
+        $derSerializer = new DerPublicKeySerializer($adapter);
+        $pemSerializer = new PemPublicKeySerializer($derSerializer);
+        $key = $pemSerializer->parse($publicKey);
+
+        $hasher = new SignHasher($algorithm);
+        $hash = $hasher->makeHash($payload, $generator);
+
+        $signer = new Signer($adapter);
+        return $signer->verify($key, $sig, $hash);
+    }
+}
+
+// Example usage -- these will come from the GitHub webhook request
+$signature = 'base64-encoded-signature';
+$publicKey = 'public-key-identifier';
+$githubToken = 'your-github-token';
+$payload = 'payload-data';
+
+$isValid = GithubSignatureVerifier::verify($signature, $publicKey, $githubToken, $payload);
+
+if ($isValid) {
+    echo "Signature is valid.";
+} else {
+    echo "Signature is invalid.";
+}

--- a/php/verify.php
+++ b/php/verify.php
@@ -3,24 +3,26 @@
 require 'vendor/autoload.php';
 
 use GuzzleHttp\Client;
-use Mdanter\Ecc\Crypto\Signature\SignHasher;
-use Mdanter\Ecc\EccFactory;
-use Mdanter\Ecc\Crypto\Signature\Signer;
-use Mdanter\Ecc\Serializer\PublicKey\PemPublicKeySerializer;
-use Mdanter\Ecc\Serializer\PublicKey\DerPublicKeySerializer;
-use Mdanter\Ecc\Serializer\Signature\DerSignatureSerializer;
 
 class GithubSignatureVerifier
 {
+    public const GITHUB_SECRET_SCANNING_KEYS_URI = "https://api.github.com/meta/public_keys/secret_scanning";
+    public const GITHUB_COPILOT_KEYS_URI = "https://api.github.com/meta/public_keys/copilot_api";
+    protected const ALGORITHM = OPENSSL_ALGO_SHA256;
+
     public static function verify(string $signature, string $publicKey, string $token, string $payload): bool
     {
         // Fetch public keys from GitHub
         $client = new Client();
-        $response = $client->get('https://api.github.com/copilot-keys', [
-            'headers' => [
-                'Authorization' => 'Bearer ' . $token,
-            ]
-        ]);
+
+        $options = [];
+        if (!empty($token)) {
+            $options['headers'] = [
+            'Authorization' => 'Bearer ' . $token,
+            ];
+        }
+
+        $response = $client->get(self::GITHUB_SECRET_SCANNING_KEYS_URI, $options);
 
         $keyResponse = json_decode($response->getBody()->getContents());
 
@@ -36,36 +38,24 @@ class GithubSignatureVerifier
             return false;
         }
 
-        // Decode the base64 signature
-        $sigData = base64_decode($signature);
+        $key = openssl_pkey_get_public($publicKey);
+        $valid = openssl_verify($payload, base64_decode($signature), $key, self::ALGORITHM);
 
-        $sigSerializer = new DerSignatureSerializer();
-        $sig = $sigSerializer->parse($sigData);
+        if ($valid < 0) {
+            echo 'Error verifying signature: ' . openssl_error_string();
+            return false;
+        }
 
-        $adapter = EccFactory::getAdapter();
-        $generator = EccFactory::getNistCurves()->generator384();
-        $algorithm = 'sha256';
-
-        // Parse public key 
-        $derSerializer = new DerPublicKeySerializer($adapter);
-        $pemSerializer = new PemPublicKeySerializer($derSerializer);
-        $key = $pemSerializer->parse($publicKey);
-
-        $hasher = new SignHasher($algorithm);
-        $hash = $hasher->makeHash($payload, $generator);
-
-        $signer = new Signer($adapter);
-        return $signer->verify($key, $sig, $hash);
+        return $valid === 1;
     }
 }
 
-// Example usage -- these will come from the GitHub webhook request
-$signature = 'base64-encoded-signature';
-$publicKey = 'public-key-identifier';
-$githubToken = 'your-github-token';
-$payload = 'payload-data';
+const PAYLOAD = '[{"source":"commit","token":"some_token","type":"some_type","url":"https://example.com/base-repo-url/"}]';
+const SIGNATURE = "MEQCIQDaMKqrGnE27S0kgMrEK0eYBmyG0LeZismAEz/BgZyt7AIfXt9fErtRS4XaeSt/AO1RtBY66YcAdjxji410VQV4xg==";
+const KEY_IDENTIFIER = "bcb53661c06b4728e59d897fb6165d5c9cda0fd9cdf9d09ead458168deb7518c";
+$token = getenv('GITHUB_PRODUCTION_TOKEN');
 
-$isValid = GithubSignatureVerifier::verify($signature, $publicKey, $githubToken, $payload);
+$isValid = GithubSignatureVerifier::verify(SIGNATURE, KEY_IDENTIFIER, $token, PAYLOAD);
 
 if ($isValid) {
     echo "Signature is valid.";


### PR DESCRIPTION
This commit adds an example of Copilot signature verification using PHP. Note that, for the sake of brevity, the composer.lock file is .gitignored.